### PR TITLE
Add Farcaster Mini App manifest

### DIFF
--- a/.well-known/farcaster.json
+++ b/.well-known/farcaster.json
@@ -1,0 +1,7 @@
+{
+  "app": {
+    "name": "playdead",
+    "icon_url": "https://playdead.ar.io/assets/icon-512.png",
+    "home_url": "https://playdead.ar.io/"
+  }
+}


### PR DESCRIPTION
This adds a /.well-known/farcaster.json file so playdead can be recognized as a Farcaster Mini App and opened directly in Warpcast or Base.
